### PR TITLE
使用支持Flask-Babel的Flake-Mako版本

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pymongo==2.8
 mongoengine==0.8.7.1
 flask-mongoengine
 flask-script
-flask-mako
+-e git+https://github.com/benselme/flask-mako.git@4c6a190a12f107d82b91e4bd60c97eab58eb4a5c#egg=Flask-Mako
 Flask-Cache
 redis
 plim


### PR DESCRIPTION
我们要使用Flask-Babel. 但是Flake-Mako很久没有release新版本, 当前pip安装的版本是旧的flaskext用法. 需要指定到新的版本