### PR TITLE
把产品环境的配置从config里面移出 放到模板中

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ Work In Process
 - react
 - oauth2
 - select2
+- flask-wtf
+- flask-restful
+- flask ext
 
 英语好的不妨看这个视频教程[http://discoverflask.com](https://github.com/realpython/discover-flask)
 
@@ -75,4 +78,4 @@ PS: 其他的firefly的依赖的列表在这里: http://python-cn.github.io/#/po
 - [ ] 个人发表的主题页
 - [ ] 徽章系统, 但是不能种类多, 我想目前只包含开发者
 - [ ] 设计一个好看的logo
-- [ ] 设计管理员系统(可能是一个子url, 也可能是一个其他的项目),就是可以开发者的权限, 有对应权限的开发者可以删帖, 修改标题等. 但是一切操作都要被系统记录
+- [ ] 设计管理员系统(可能是一个子url, 也可能是一个其他的项目),就是可以开发者的权限, 有对应权限的开发者可以删帖, 修改标题等. 但是一切操作都要被系统记录(flask-admin好丑)

--- a/firefly/config.py
+++ b/firefly/config.py
@@ -1,30 +1,18 @@
 # coding=utf-8
+'''
+这里firefly的默认配置
+'''
+from __future__ import print_function
 from plim import preprocessor
 
-SECRET_KEY = '\x97\xfa%\xab\xd2\xc2\xf8\xfc\xef\xaeTKDk\xc0\xe1//($\xc7\xc0'
+SECRET_KEY = 'you need modify this into local_settings.py'
 
 # plim
 MAKO_DEFAULT_FILTERS = ['decode.utf_8', 'h']
 MAKO_PREPROCESSOR = preprocessor
 MAKO_TRANSLATE_EXCEPTIONS = False
 
-# mongodb
-MONGODB_SETTINGS = {
-    'db': 'test',
-    'username': '',
-    'password': '',
-    'host': '127.0.0.1',
-    'port': 27017
-}
-
 MAX_CONTENT_LENGTH = 16 * 1024 * 1024
-
-# redis cache
-CACHE_TYPE = 'redis'
-CACHE_REDIS_HOST = '127.0.0.1'
-CACHE_REDIS_PORT = 6379
-CACHE_REDIS_DB = ''
-CACHE_REDIS_PASSWORD = ''
 
 # available languages
 LANGUAGES = {
@@ -33,3 +21,10 @@ LANGUAGES = {
 }
 
 BABEL_DEFAULT_LOCALE = 'zh'
+
+try:
+    from local_settings import *  # noqa
+except ImportError:
+    print('You need rename local_config.py.example to local_config.py, '
+          'then update your settings')
+    raise

--- a/firefly/local_settings.py.example
+++ b/firefly/local_settings.py.example
@@ -1,0 +1,19 @@
+# coding=utf-8
+
+SECRET_KEY = '\x97\xfa%\xab\xd2\xc2\xf8\xfc\xef\xaeTKDk\xc0\xe1//($\xc7\xc0'
+
+# mongodb
+MONGODB_SETTINGS = {
+    'db': 'test',
+    'username': '',
+    'password': '',
+    'host': '127.0.0.1',
+    'port': 27017
+}
+
+# redis cache
+CACHE_TYPE = 'redis'
+CACHE_REDIS_HOST = '127.0.0.1'
+CACHE_REDIS_PORT = 6379
+CACHE_REDIS_DB = ''
+CACHE_REDIS_PASSWORD = ''


### PR DESCRIPTION
@halfcrazy @mozillazg 我修改了一下逻辑

把数据库, redis, 以后要上的oauth2配置都放在本地的文件中. config.py 只包含常规的配置.

本地开发的时候:

```python
cp firefly/local_settings.py.example firefly/local_settings.py
# 修改本地配置
```