### PR TITLE
add python-cn fork flask-social-blueprint to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ httplib2
 requests
 requests-oauthlib
 py-bcrypt
+git+git://github.com/python-cn/flask-social-blueprint


### PR DESCRIPTION
明哥我看你新提交了auth功能，然后我这就报错提示没有响应的module，我就在requirements.txt中添加了python-cn frok的 flask-social-blueprint ，已经测试通过可以正常跑通。您看下我增加的这个合不合理？