### PR TITLE
python3 porting

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # -*- coding: utf-8 -*-
 
 import pytest

--- a/firefly/app.py
+++ b/firefly/app.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # coding=utf-8
 import os
 
@@ -84,7 +85,7 @@ def register_hooks(app):
     @babel.localeselector
     def get_locale():
         return request.accept_languages.best_match(
-            app.config['LANGUAGES'].keys()
+            list(app.config['LANGUAGES'].keys())
         ) or app.config['BABEL_DEFAULT_LOCALE']
 
     @app.before_request

--- a/firefly/config.py
+++ b/firefly/config.py
@@ -3,6 +3,7 @@
 firefly settings
 '''
 from __future__ import print_function
+from __future__ import absolute_import
 from plim import preprocessor
 
 SECRET_KEY = 'you need modify this into local_settings.py'
@@ -36,7 +37,7 @@ SECURITY_DEFAULT_REMEMBER_ME = True
 CSRF_ENABLED = True
 
 try:
-    from local_settings import *  # noqa
+    from .local_settings import *  # noqa
 except ImportError:
     print('You need rename local_config.py.example to local_config.py, '
           'then update your settings')

--- a/firefly/ext.py
+++ b/firefly/ext.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # coding=utf-8
 from flask import current_app
 from flask_babel import Babel

--- a/firefly/libs/markdown.py
+++ b/firefly/libs/markdown.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # coding=utf-8
 import mistune
 from pygments import highlight

--- a/firefly/models/topic.py
+++ b/firefly/models/topic.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 '''Define Schema'''
+from __future__ import absolute_import
 
 from datetime import datetime
 

--- a/firefly/models/user.py
+++ b/firefly/models/user.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 '''Define Schema'''
+from __future__ import absolute_import
 
 from datetime import datetime
 

--- a/firefly/utils.py
+++ b/firefly/utils.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # coding=utf-8
 from functools import wraps
 

--- a/firefly/views/api/__init__.py
+++ b/firefly/views/api/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # coding=utf-8
 from flask import Blueprint
 from flask_restful import Api

--- a/firefly/views/api/category.py
+++ b/firefly/views/api/category.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # coding=utf-8
 from collections import OrderedDict
 

--- a/firefly/views/api/user.py
+++ b/firefly/views/api/user.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # coding=utf-8
 from flask_security import login_required
 from flask_login import current_user

--- a/firefly/views/auth.py
+++ b/firefly/views/auth.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # coding=utf-8
 from flask.blueprints import Blueprint
 from flask_mako import render_template

--- a/firefly/views/category.py
+++ b/firefly/views/category.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # coding=utf-8
 from flask.views import MethodView
 from flask.blueprints import Blueprint

--- a/firefly/views/home.py
+++ b/firefly/views/home.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # coding=utf-8
 from flask import request, jsonify, redirect, url_for
 from flask.views import MethodView

--- a/firefly/views/keyboard.py
+++ b/firefly/views/keyboard.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # coding=utf-8
 from flask import request
 from flask.views import MethodView

--- a/firefly/views/post.py
+++ b/firefly/views/post.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # coding=utf-8
 from flask import request, redirect, url_for
 from flask.views import MethodView

--- a/firefly/views/utils.py
+++ b/firefly/views/utils.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # coding=utf-8
 import arrow
 

--- a/manage.py
+++ b/manage.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # coding=utf-8
 
 from flask_script import Manager, Server

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # coding=utf-8
 import os
 import sys

--- a/tests/test_category.py
+++ b/tests/test_category.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # coding: utf-8 -*-
 
 from flask import url_for

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # coding: utf-8 -*-
 
 from flask import url_for

--- a/tests/test_post.py
+++ b/tests/test_post.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # coding: utf-8 -*-
 
 from flask import url_for


### PR DESCRIPTION
我已经更新了guide. 添加了python3代码支持的说明. [写python3兼容的代码](http://python-cn.org/#/post/porting3.md). 

使用`from __future__ import absolute_import`是因为python3不支持`Implicit relative imports`

比如我之前的[PPT](http://dongweiming.github.io/Expert-Python/#11). 在python3下是被强制absolute_import的:

```python
python
Python 2.7.3 (default, Apr 10 2013, 06:20:15) 
[GCC 4.6.3] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> from for_absolute_import.main import string
>>> string
<module 'for_absolute_import.string' from 'for_absolute_import/string.py'>
>>> 
python3
Python 3.4.2+ (3.4:463bbd862887, Jan 26 2015, 22:09:39) 
[GCC 4.6.3] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from for_absolute_import.main import string
>>> string
<module 'string' from '/usr/local/lib/python3.4/string.py'>
```