### PR TITLE
due to the newest version of pyflake8 was not supported, upgrade pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    sha: 9ce45609a92f648c87b42207410386fd69a5d1e5
+    sha: 616c1ebd1898c91de9a0548866a59cbd9f4547f6
     hooks:
     -   id: autopep8-wrapper
         args: ['-i', '--ignore=E309']


### PR DESCRIPTION
由于原先版本中指定的pre-commit版本不支持最新的pyflake8，更新pre-commit hook中的sha为最新版本